### PR TITLE
Swap control::Control<B> for std::ops::ControlFlow<B, ()>

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -3,7 +3,7 @@
 macro_rules! try_control {
     ($e:expr) => {
         let x = $e;
-        if x.should_break() {
+        if x.is_break() {
             return x;
         }
     };
@@ -15,7 +15,7 @@ macro_rules! try_control {
 #[allow(clippy::module_name_repetitions)]
 pub trait ControlFlow {
     #[inline]
-    fn should_break(&self) -> bool {
+    fn is_break(&self) -> bool {
         false
     }
 }
@@ -23,13 +23,13 @@ pub trait ControlFlow {
 impl ControlFlow for () {}
 
 impl<B> ControlFlow for std::ops::ControlFlow<B, ()> {
-    fn should_break(&self) -> bool {
+    fn is_break(&self) -> bool {
         matches!(self, Self::Break(_))
     }
 }
 
 impl<E> ControlFlow for Result<(), E> {
-    fn should_break(&self) -> bool {
+    fn is_break(&self) -> bool {
         self.is_err()
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -2,12 +2,9 @@
 
 macro_rules! try_control {
     ($e:expr) => {
-        match $e {
-            x => {
-                if x.should_break() {
-                    return x;
-                }
-            }
+        let x = $e;
+        if x.should_break() {
+            return x;
         }
     };
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -17,30 +17,21 @@ macro_rules! try_control {
 /// The empty return value `()` is equivalent to continue.
 #[allow(clippy::module_name_repetitions)]
 pub trait ControlFlow {
-    fn continuing() -> Self;
     #[inline]
     fn should_break(&self) -> bool {
         false
     }
 }
 
-impl ControlFlow for () {
-    fn continuing() {}
-}
+impl ControlFlow for () {}
 
 impl<B> ControlFlow for std::ops::ControlFlow<B, ()> {
-    fn continuing() -> Self {
-        Self::Continue(())
-    }
     fn should_break(&self) -> bool {
         matches!(self, Self::Break(_))
     }
 }
 
 impl<E> ControlFlow for Result<(), E> {
-    fn continuing() -> Self {
-        Ok(())
-    }
     fn should_break(&self) -> bool {
         self.is_err()
     }

--- a/src/control.rs
+++ b/src/control.rs
@@ -14,29 +14,6 @@ macro_rules! try_control {
 
 /// Control flow for callbacks.
 ///
-/// `Break` can carry a value.
-#[derive(Copy, Clone, Debug)]
-pub enum Control<B> {
-    Continue,
-    Break(B),
-}
-
-impl<B> Control<B> {
-    #[must_use]
-    pub const fn breaking() -> Control<()> {
-        Control::Break(())
-    }
-    /// Get the value in `Control::Break(_)`, if present.
-    pub fn break_value(self) -> Option<B> {
-        match self {
-            Self::Continue => None,
-            Self::Break(b) => Some(b),
-        }
-    }
-}
-
-/// Control flow for callbacks.
-///
 /// The empty return value `()` is equivalent to continue.
 #[allow(clippy::module_name_repetitions)]
 pub trait ControlFlow {
@@ -51,9 +28,9 @@ impl ControlFlow for () {
     fn continuing() {}
 }
 
-impl<B> ControlFlow for Control<B> {
+impl<B> ControlFlow for std::ops::ControlFlow<B, ()> {
     fn continuing() -> Self {
-        Self::Continue
+        Self::Continue(())
     }
     fn should_break(&self) -> bool {
         matches!(self, Self::Break(_))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ use crate::control::ControlFlow;
 /// a bit faster than the iterative version.
 ///
 /// The closure `f` may return either `()` to simply run through all
-/// permutations, or a [`std::ops::ControlFlow<B, ()>`] value that permits
-/// breaking the iteration early.
+/// permutations, or a [`std::ops::ControlFlow<B, ()>`](std::ops::ControlFlow)
+/// value that permits breaking the iteration early.
 ///
 /// ```
 /// use permutohedron::heap_recursive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ use crate::control::ControlFlow;
 /// a bit faster than the iterative version.
 ///
 /// The closure `f` may return either `()` to simply run through all
-/// permutations, or a `Control` value that permits breaking the
-/// iteration early.
+/// permutations, or a [`std::ops::ControlFlow<B, ()>`] value that permits
+/// breaking the iteration early.
 ///
 /// ```
 /// use permutohedron::heap_recursive;
@@ -230,7 +230,6 @@ pub fn factorial(n: usize) -> usize {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
-    use crate::control::Control;
 
     #[test]
     fn first_and_reset() {
@@ -331,9 +330,9 @@ mod tests {
         heap_recursive(&mut data, |_perm| {
             i += 1;
             if i >= 10_000 {
-                Control::Break(i)
+                std::ops::ControlFlow::Break(i)
             } else {
-                Control::Continue
+                std::ops::ControlFlow::Continue(())
             }
         });
         assert_eq!(i, 10_000);


### PR DESCRIPTION
This addresses #10 in a way that still makes `(): control::ControlFlow`.

EDIT: this also removes an unused function, and makes some small code changes to match some of the `std::ops::ControlFlow` API. No functionality is lost, but it might break code of anyone calling methods on `control::ControlFlow`...