### PR TITLE
Wrap all tests in #[cfg(test)]

### DIFF
--- a/src/lexical.rs
+++ b/src/lexical.rs
@@ -108,21 +108,26 @@ where
     }
 }
 
-#[test]
-fn lexical() {
-    let mut data = [1, 2, 3];
-    data.next_permutation();
-    assert_eq!(&data, &[1, 3, 2]);
-    data.next_permutation();
-    assert_eq!(&data, &[2, 1, 3]);
-    data.prev_permutation();
-    assert_eq!(&data, &[1, 3, 2]);
-    data.prev_permutation();
-    assert_eq!(&data, &[1, 2, 3]);
-    assert!(!data.prev_permutation());
-    let mut c = 0;
-    while data.next_permutation() {
-        c += 1;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lexical() {
+        let mut data = [1, 2, 3];
+        data.next_permutation();
+        assert_eq!(&data, &[1, 3, 2]);
+        data.next_permutation();
+        assert_eq!(&data, &[2, 1, 3]);
+        data.prev_permutation();
+        assert_eq!(&data, &[1, 3, 2]);
+        data.prev_permutation();
+        assert_eq!(&data, &[1, 2, 3]);
+        assert!(!data.prev_permutation());
+        let mut c = 0;
+        while data.next_permutation() {
+            c += 1;
+        }
+        assert_eq!(c, 5);
     }
-    assert_eq!(c, 5);
 }


### PR DESCRIPTION
This just wraps the test in `src/lexical.rs` in a `#[cfg(test)]` block.